### PR TITLE
Inheritance support for NSObject-NSCoding

### DIFF
--- a/NSObject+NSCoding.m
+++ b/NSObject+NSCoding.m
@@ -65,10 +65,11 @@
             case '@':   // object
                 if ([[type componentsSeparatedByString:@"\""] count] > 1) {
                     className = [[type componentsSeparatedByString:@"\""] objectAtIndex:1];
+                    Class class = NSClassFromString(className);
                     value = [self performSelector:NSSelectorFromString(key)];
 
                     // only decode if the property conforms to NSCoding
-                    if (class_conformsToProtocol(NSClassFromString(className), @protocol(NSCoding))) {
+                    if([class conformsToProtocol:@protocol(NSCoding)]){
                         [coder encodeObject:value forKey:key];
                     }
                 }
@@ -131,8 +132,9 @@
             case '@':   // object
                 if ([[type componentsSeparatedByString:@"\""] count] > 1) {
                     className = [[type componentsSeparatedByString:@"\""] objectAtIndex:1];                    
+                    Class class = NSClassFromString(className);
                     // only decode if the property conforms to NSCoding
-                    if (class_conformsToProtocol(NSClassFromString(className), @protocol(NSCoding))) {
+                    if ([class conformsToProtocol:@protocol(NSCoding )]){
                         value = [[coder decodeObjectForKey:key] retain];
                         addr = (NSInteger)&value;
                         object_setInstanceVariable(self, [key UTF8String], *(id**)addr);


### PR DESCRIPTION
Support for objects indirectly (via Base Class) conform to NSCoding protocol (e.g. NSMutableDictionary).
class_conformsToProtocol doesn't take inheritance into account (http://stackoverflow.com/questions/4974950/objective-c-class-conformstoprotocol-bug/4975224#4975224)
